### PR TITLE
Fix: Correct UnboundLocalError in tracker_io.py logging

### DIFF
--- a/cline_utils/dependency_system/io/tracker_io.py
+++ b/cline_utils/dependency_system/io/tracker_io.py
@@ -1433,7 +1433,7 @@ def update_tracker(output_file_suggestion: str, # Path suggestion (may be ignore
                     # Apply if forcing, suggestion isn't placeholder, and it's different
                     if dep_char != PLACEHOLDER_CHAR and existing_char_in_grid != dep_char:
                         should_apply_suggestion = True
-                        logger.debug(f"Force apply triggered for {row_key}->{col_key} ('{dep_char}') over ('{existing_char_in_grid}')")
+                        logger.debug(f"Force apply triggered for {source_key}->{target_key} ('{dep_char}') over ('{existing_char_in_grid}')")
                 elif existing_char_in_grid == PLACEHOLDER_CHAR and dep_char != PLACEHOLDER_CHAR:
                      # Apply if grid is placeholder and suggestion isn't
                      should_apply_suggestion = True


### PR DESCRIPTION
Resolves an UnboundLocalError that occurred in the function within .

The error was triggered when  was True (e.g.,
during an  command) due to an f-string in a
 statement referencing an undefined  variable.

This commit corrects the variable names in the problematic logging statement to use  and , which are defined
in that scope. This ensures the  command and other operations relying on  can execute
without error.

Affected file: cline_utils/dependency_system/io/tracker_io.py